### PR TITLE
Wrong type assertion in integration test

### DIFF
--- a/tests/integration/CodeParserTest.php
+++ b/tests/integration/CodeParserTest.php
@@ -229,7 +229,7 @@ class CodeParserTest extends \PHPUnit_Framework_TestCase
         $param = $method->params['a'];
         self::assertSame('a', $param->name);
         self::assertNull($param->default);
-        self::assertNull($param->type);
+        self::assertSame('int', $param->type);
         self::assertFalse($param->byRef);
         self::assertFalse($param->isVariadic);
 
@@ -237,7 +237,7 @@ class CodeParserTest extends \PHPUnit_Framework_TestCase
         $param = $method->params['b'];
         self::assertSame('b', $param->name);
         self::assertSame(1, $param->default);
-        self::assertNull($param->type);
+        self::assertSame('int', $param->type);
         self::assertTrue($param->byRef);
         self::assertFalse($param->isVariadic);
 


### PR DESCRIPTION
This PR fixes the following:

```
There was 1 failure:

1) CodeDocs\Test\Integration\CodeParserTest::testParser
Failed asserting that 'int' is null.

.../codedocs/tests/integration/CodeParserTest.php:232
.../codedocs/tests/integration/CodeParserTest.php:25
```

The parser takes the type hint from the doc block. In the test case it's `int`, so the assertion to `null` fails.
