### PR TITLE
Support PHP 5.6

### DIFF
--- a/src/Doc/Invoker.php
+++ b/src/Doc/Invoker.php
@@ -67,7 +67,7 @@ class Invoker
         $types     = [];
 
         foreach ($refParams as $idx => $refParam) {
-            $types[] = (string)$refParam->getType();
+            $types[] = $this->getType($refParam);
 
             if (isset($func->params[$refParam->name])) {
                 $params[] = $func->params[$refParam->name];
@@ -147,5 +147,25 @@ class Invoker
         }
 
         return $value;
+    }
+
+    /**
+     * @param ReflectionParameter $param
+     *
+     * @return string
+     */
+    private function getType(ReflectionParameter $param)
+    {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+            return (string) $param->getType();
+        }
+
+        // fallback for PHP < 7.0
+        // try to match type hint from stringified parameter, e.g. "Parameter #0 [ <required> int $foo ]"
+        if (preg_match('/\<\w+?\> (?<type>\w+)/', (string) $param, $matches)) {
+            return $matches['type'];
+        }
+
+        return '';
     }
 }

--- a/src/Doc/Invoker.php
+++ b/src/Doc/Invoker.php
@@ -162,7 +162,7 @@ class Invoker
 
         // fallback for PHP < 7.0
         // try to match type hint from stringified parameter, e.g. "Parameter #0 [ <required> int $foo ]"
-        if (preg_match('/\<\w+?\> (?<type>\w+)/', (string) $param, $matches)) {
+        if (preg_match('/\<\w+?\> (?<type>[\w\\\\]+)/', (string) $param, $matches)) {
             return $matches['type'];
         }
 


### PR DESCRIPTION
This PR brings PHP 5.6 compatibility back. The `ReflectionParameter::getType()` was introduced with PHP 7.0, so I added a fallback for previous PHP versions.

I'm not sure, if that class is the right place for the fix, so I need some feedback here.
