### PR TITLE
PHP 7.4 support

### DIFF
--- a/src/Doc/Lexer.php
+++ b/src/Doc/Lexer.php
@@ -178,12 +178,14 @@ class Lexer
             $string = substr($string, 1);
 
             $typeInfo = $this->scanNextType($string);
-
+            if ($typeInfo === null) {
+                break;
+            }
             // ignore all until markup reached
             if ($typeInfo['type'] !== self::T_MARKUP_OPEN && $typeInfo['type'] !== self::T_MARKUP_OPEN_ESCAPED) {
-                $typeInfo = null;
+                break;
             }
-        } while ($typeInfo === null && $string);
+        } while ($string);
 
         return [
             'type'   => self::T_ANY,


### PR DESCRIPTION
With PHP7.4 we're getting this error, as `$typeInfo` might be null already which is failing in array access:
```
PHP Notice:  Trying to access array offset on value of type null in vendor/erusev/parsedown-extra/ParsedownExtra.php on line 241
```