### PR TITLE
Added support for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,14 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+
+dist: trusty
+
 php:
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "nikic/php-parser": "^4.2",
     "doctrine/annotations": "^1.2"
   },


### PR DESCRIPTION
Just increased the min-version in composer.json to make it possible to use this package with PHP8.0:
- runs still fine on our code base
- no BCs visible