### PR TITLE
adding support for typed properties/parameters

### DIFF
--- a/src/SourceCode/Ref/RefProperty.php
+++ b/src/SourceCode/Ref/RefProperty.php
@@ -37,4 +37,9 @@ class RefProperty
      * @var RefComment|null
      */
     public $docComment;
+
+    /**
+     * @var string|null
+     */
+    public $type;
 }


### PR DESCRIPTION
- don't add namespace to scalar types ("Identifiers")
- parse type for class properties from both class definition & phpdoc (to allow overriding the type just like for params)